### PR TITLE
TokenStream class/test

### DIFF
--- a/ide/vs2012/plang.vcxproj
+++ b/ide/vs2012/plang.vcxproj
@@ -73,11 +73,13 @@
     <ClInclude Include="..\..\src\plang\parser.h" />
     <ClInclude Include="..\..\src\plang\plang.h" />
     <ClInclude Include="..\..\src\plang\token.h" />
+    <ClInclude Include="..\..\src\plang\TokenStream.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\src\plang\expression.cpp" />
     <ClCompile Include="..\..\src\plang\parser.cpp" />
     <ClCompile Include="..\..\src\plang\token.cpp" />
+    <ClCompile Include="..\..\src\plang\TokenStream.cpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/ide/vs2012/plang.vcxproj.filters
+++ b/ide/vs2012/plang.vcxproj.filters
@@ -6,10 +6,12 @@
     <ClInclude Include="..\..\src\plang\expression.h" />
     <ClInclude Include="..\..\src\plang\parser.h" />
     <ClInclude Include="..\..\src\plang\token.h" />
+    <ClInclude Include="..\..\src\plang\TokenStream.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\src\plang\expression.cpp" />
     <ClCompile Include="..\..\src\plang\parser.cpp" />
     <ClCompile Include="..\..\src\plang\token.cpp" />
+    <ClCompile Include="..\..\src\plang\TokenStream.cpp" />
   </ItemGroup>
 </Project>

--- a/src/plang/TokenStream.cpp
+++ b/src/plang/TokenStream.cpp
@@ -1,0 +1,97 @@
+#include <plang/TokenStream.h>
+
+using namespace plang;
+
+static const char* kOpTokenStrings[] =
+{
+//	arithmetic
+	"=", "+", "-", "/", "*", 
+//	control
+	":", "(", ")", "{", "}",
+};
+
+////////////////////////////////////////////////////////////////////////////////
+static bool isWhiteSpace(char _c)
+{
+	//static const char* kWhitespace = " \t\n";
+	//for (const char* it = kWhitespace; *it != 0; ++it) {
+	//	if (_c == *it) {
+	//		return true;
+	//	}
+	//}
+	//return false;
+	return _c <= ' '; // optim, just assume all ASCII control chars are whitespace
+}
+
+////////////////////////////////////////////////////////////////////////////////
+static const char* getOpTokenString(char _c)
+{
+	for (const char** it = kOpTokenStrings; *it != 0; ++it) {
+		if (_c == **it) {
+			return *it;
+		}
+	}
+	return 0;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+TokenStream::TokenStream(char* _buf_)
+	: m_buf(_buf_)
+	, m_optoken(0)
+{
+//	advance to first token
+	while (*m_buf && isWhiteSpace(*m_buf)) {
+		++m_buf;
+	}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+const char* TokenStream::getNext()
+{
+// if m_optoken was set, interrupt the stream and return an op token string (we 
+// can't guarantee to insert a null char after an op token)
+	if (m_optoken) {
+		const char* ret = m_optoken;
+		m_optoken = 0;
+		return ret;
+	}
+
+// detect end of stream
+	if (!m_buf) {
+		return 0; 
+	}
+
+// advance to next non-whitespace char (start of the next token)
+	while (*m_buf && isWhiteSpace(*m_buf)) {
+		++m_buf;
+	}
+	const char* ret = m_buf;
+
+// advance to next whitespace char, op token or eos
+	while (*m_buf && !isWhiteSpace(*m_buf)) {
+		m_optoken = getOpTokenString(*m_buf);
+		if (m_optoken) {
+			break; // break here, optoken in m_buf is replaced with 0
+		}
+		++m_buf;
+	}
+	if (*m_buf) {
+	// replace whitespace with 0
+		*m_buf = 0;
+		++m_buf;
+	} else {
+	// signal eos
+		m_buf = 0;
+	}
+
+// special case; ret can be null if we have an op token first in the stream 
+// (or if the stream contains consecutive op tokens), in which case we can
+// consume m_optoken here
+	if (*ret == 0) {
+		ret = m_optoken;
+		m_optoken = 0;
+	}
+
+	return ret;
+}

--- a/src/plang/TokenStream.h
+++ b/src/plang/TokenStream.h
@@ -1,0 +1,28 @@
+#ifndef plang_TokenStream_h
+#define plang_TokenStream_h
+
+namespace plang {
+
+////////////////////////////////////////////////////////////////////////////////
+/// \class TokenStream
+/// Returns tokens sequentially from a char stream.
+////////////////////////////////////////////////////////////////////////////////
+class TokenStream
+{
+public:
+	/// Init from an existing char buffer.
+	/// \note The buffer is modified by calls to \c getNext().
+	TokenStream(char* _buf_);
+
+	/// \return The next token in the stream (a null-terminated string). 
+	const char* getNext();
+
+private:	
+	char* m_buf;
+	const char* m_optoken;
+
+}; // class TokenStream
+
+} // namespace plang
+
+#endif // plang_TokenStream_h

--- a/src/plang_go/main.cpp
+++ b/src/plang_go/main.cpp
@@ -1,24 +1,33 @@
-#include <iostream>
-
 #include <plang/plang.h>
-#include <plang/parser.h>
+#include <plang/TokenStream.h>
+
+#include <iostream>
 
 using namespace plang;
 
 int main(int argc, char** argv)
 {
-  Parser parser = Parser();
-
+	// this is rather shitty code, just an adhoc test for the token stream
+	const int kBufSize = 1024;
+	char buf[kBufSize];
 	while (true) {
-  		std::string input;
-  		std::cout << "> ";
-  		getline(std::cin, input);
-
-      if (input == "exit")
-      {
-        return 0;
-      }
-
-      std::cout << parser.parse(input) << "\n";
-  }
+		std::cout << ">";
+		std::cin.getline(buf, kBufSize);
+		plang::TokenStream tokstr(buf);
+		const char* tok;
+		while ((tok = tokstr.getNext()) != 0) {
+			if (tok[0] == ':') {
+				if ((tok = tokstr.getNext()) != 0) {
+					if (tok[0] == 'q') {
+						goto plang_go_end;
+					}
+				}	
+			} else {
+				std::cout << tok << "_";
+			}
+		}
+		std::cout << std::endl;
+	}
+plang_go_end: // I really just wanted to use a goto
+	return 0;
 }


### PR DESCRIPTION
@thesheps 

I bashed out a little class called TokenStream. It's not very beautiful but it's very efficient and should be useful as a way of tokenising input to the parser. Here's how it works:

You start with a buffer of char (from a file, from command line input, from the network, whatever). You create a TokenStream instance and give it this buffer. Every time you call getNext() on the token stream it parses forward a little bit and then returns either a null-terminated string (const char*) representing the next token or 0 if the stream ended.

The nice thing is that it doesn't allocate any extra memory internally, but to achieve this I clobber the input buffer (it inserts null terminators after each token it finds). So for example an input buffer "32 + 4" will end up looking like "320+04" (after 3 calls to getNext() which return "32" "+" and "4" respectively). This means that you can't rewind the token stream or reuse it after you call getNext() all the way to the end, but implementing the shunting algorithm we don't need that.

I modified pgo with an adhoc test to play with this; it tokenises anything you type, quit by entering ":q"
